### PR TITLE
Using java command instead of ./  and using -s 128/1024 instead of -f

### DIFF
--- a/1-cpu_cache/traverse_1d_array/README.md
+++ b/1-cpu_cache/traverse_1d_array/README.md
@@ -40,7 +40,7 @@
        0.004098000 seconds sys
 ```
 #### 以步长为128遍历数组
-`perf stat -e cache-references,cache-misses,instructions,cycles,L1-dcache-load-misses,L1-dcache-loads ./traverse_1d_array -f`
+`perf stat -e cache-references,cache-misses,instructions,cycles,L1-dcache-load-misses,L1-dcache-loads ./traverse_1d_array -s 128`
 * 输出结果：
 ```
         34,246,770      cache-references                                              (83.16%)
@@ -57,7 +57,7 @@
 
 ```
 #### 以步长为1024遍历数组
-`perf stat -e cache-references,cache-misses,instructions,cycles,L1-dcache-load-misses,L1-dcache-loads ./traverse_1d_array -f`
+`perf stat -e cache-references,cache-misses,instructions,cycles,L1-dcache-load-misses,L1-dcache-loads ./traverse_1d_array -s 1024`
 * 输出结果：
 ```
        148,684,923      cache-references                                              (83.32%)

--- a/1-cpu_cache/traverse_2d_array/README.md
+++ b/1-cpu_cache/traverse_2d_array/README.md
@@ -66,7 +66,7 @@
 消耗时间（毫秒）：100
 ### c. 使用perf验证缓存命中率
 #### 使用array[i][j]遍历数组
-`perf stat -e cache-references,cache-misses,instructions,cycles,L1-dcache-load-misses,L1-dcache-loads ./traverse_2d_array -f`
+`perf stat -e cache-references,cache-misses,instructions,cycles,L1-dcache-load-misses,L1-dcache-loads java traverse_2d_array -f`
 * 输出结果：
 ```
  Performance counter stats for 'java traverse_2d_array -f':
@@ -84,7 +84,7 @@
        0.047877000 seconds sys
 ```
 #### 使用array[j][i]遍历数组
-`perf stat -e cache-references,cache-misses,instructions,cycles,L1-dcache-load-misses,L1-dcache-loads ./traverse_2d_array -s`
+`perf stat -e cache-references,cache-misses,instructions,cycles,L1-dcache-load-misses,L1-dcache-loads java traverse_2d_array -s`
 * 输出结果：
 ```
  Performance counter stats for 'java traverse_2d_array -s':


### PR DESCRIPTION
Hello teacher, I found there is a little mistakes in README.md at geektime_distrib_perf\1-cpu_cache\traverse_2d_array, I think you want to show us the performace of java language, right?